### PR TITLE
Fix issue #9 - Using Ctrl-C instead of <ESC> does not trigger the plugin

### DIFF
--- a/plugin/numbers.vim
+++ b/plugin/numbers.vim
@@ -76,6 +76,7 @@ augroup NumbersAug
     au!
     autocmd InsertEnter * :call SetNumbers()
     autocmd InsertLeave * :call SetRelative()
+    autocmd CursorMoved * :call SetRelative()
     autocmd BufNewFile  * :call ResetNumbers()
     autocmd BufReadPost * :call ResetNumbers()
     autocmd FocusLost   * :call Uncenter()


### PR DESCRIPTION
I added a new event so Ctrl-C works the same way <ESC> (set to relative number).
