### PR TITLE
Set numberwidth appropriately when opening large files

### DIFF
--- a/plugin/numbers.vim
+++ b/plugin/numbers.vim
@@ -71,6 +71,20 @@ function! Uncenter()
     call ResetNumbers()
 endfunc
 
+" To be technically correct this would be called on InsertLeave rather than
+" on BufReadPost, because what happens when someone opens a file with 999
+" lines and then adds one more? But I didn't have the heart to add overhead to
+" every single mode shift for the sake of such a rare occurrence.
+function! SetWidth()
+    if(line("$") >= 10000)
+        set numberwidth=6
+    elseif(line("$") >= 1000)
+        set numberwidth=5
+    else
+        set numberwidth=4
+    end
+endfunc
+
 " Triggers mode based on events
 augroup NumbersAug
     au!
@@ -78,6 +92,7 @@ augroup NumbersAug
     autocmd InsertLeave * :call SetRelative()
     autocmd BufNewFile  * :call ResetNumbers()
     autocmd BufReadPost * :call ResetNumbers()
+    autocmd BufReadPost * :call SetWidth()
     autocmd FocusLost   * :call Uncenter()
     autocmd FocusGained * :call Center()
 augroup END


### PR DESCRIPTION
Previously, opening a file with >1000 lines would cause the columns to
jump around when entering/leaving insert mode because of the length
mismatch between number and relativenumber. Now it checks the
linecount when opening a file and sets the line number appropriately.
