### PR TITLE
Add a way to temporarily disable line numbering.

### DIFF
--- a/plugin/numbers.vim
+++ b/plugin/numbers.vim
@@ -41,10 +41,19 @@ function! SetRelative()
     call ResetNumbers()
 endfunc
 
+function! SetOff()
+    let g:mode = 2
+    call ResetNumbers()
+endfunc
+
 function! NumbersToggle()
     if (g:mode == 1)
         let g:mode = 0
         set relativenumber
+    elseif (g:mode == 0)
+        let g:mode == 2
+        set nonumber
+        set norelativenumber
     else
         let g:mode = 1
         set number
@@ -56,6 +65,9 @@ function! ResetNumbers()
         set number
     elseif(g:mode == 0)
         set relativenumber
+    elseif(g:mode == 2)
+        set norelativenumber
+        set nonumber
     else
         set number
     end


### PR DESCRIPTION
This has not been tested, and is probably done in a stupid way since I do not know vimL.

But the reasoning behind this is that I sometimes have to copy stuff out of vim to another terminal or a browser, and the line numbers get in the way.

I know you can just do :set nonumbers and :set norelativenumbers, but I figured it would be nice to be able to switch between having absolute, relative and no line numbers with the plugin.
