### PR TITLE
Switch line number based on whether a buffer is active

### DIFF
--- a/plugin/numbers.vim
+++ b/plugin/numbers.vim
@@ -82,6 +82,8 @@ function! NumbersEnable()
     let g:enable_numbers = 1
     augroup NumbersAug
         au!
+        autocmd BufLeave *    :call SetNumbers()
+        autocmd BufEnter *    :call SetRelative()
         autocmd InsertEnter * :call SetNumbers()
         autocmd InsertLeave * :call SetRelative()
         autocmd BufNewFile  * :call ResetNumbers()


### PR DESCRIPTION
Great plugin! It solves a common vim pain point for me - I want to use relative line numbers while I'm editing a buffer, but often need absolute line numbers for use with external tools like gdb.

This pull request makes it fit my workflow a little better, since I often use gdb in a ConqueTerm inside vim. With this change, switching away from a buffer to a different split (say, from source code to gdb) activates absolute line numbers, making it easy to set breakpoints and such, and switching back reactivates relative line numbers. I think this will be very helpful for others like me and will hurt no one, since relative numbers don't matter much when a buffer isn't active.
