### PR TITLE
Use norelativenumber instead of number

### DIFF
--- a/plugin/numbers.vim
+++ b/plugin/numbers.vim
@@ -55,17 +55,17 @@ function! NumbersToggle()
         set relativenumber
     else
         let s:mode = 1
-        set number
+        set norelativenumber
     endif
 endfunc
 
 function! ResetNumbers()
     if(s:center == 0)
-        set number
+        set norelativenumber
     elseif(s:mode == 0)
         set relativenumber
     else
-        set number
+        set norelativenumber
     end
 endfunc
 


### PR DESCRIPTION
- This plugin is better for just modifying the `relativenumber` option since it only supports two states. The last commit removes modifications of the `number` option by setting `norelativenumber`.
- Use `s:` prefixed vars for proper scope. `g:` means global which means other plugins can modify it. Furthermore, `g:mode` and `g:center` are not very unique names that might get used elsewhere.
- Fixed some inconsistent tab styling. I notice some other people did this too in their pull-requests.

If you have any questions or want help with the merging or anything let me know. I'm not very handy with vim script but I'll do my best.  Anyways, this plugin is a very good idea but it can be made much better if you merge the PR's currently against it.
