### PR TITLE
Opiniated rewrite and better handling of state

### DIFF
--- a/plugin/numbers.vim
+++ b/plugin/numbers.vim
@@ -55,7 +55,7 @@ augroup END
 function! s:relative_off()
     if v:version > 703 || (v:version == 703 && has('patch1115'))
         set norelativenumber
-    elseif
+    else
         set number
     endif
 endfunction


### PR DESCRIPTION
This is a major (opinionated) rewrite to do the following:
- Always keep track of state just don't modify nu or rnu options if
  disabled by setting up auto command group and never disabling it.
- Rename and reorder functions based on calling order and necessary
  scope.
- Save user settings during NumbersEnable and reset them when disabled

In general I think these are good changes. I understand this is quite a few changes though. It is ideal behaviour for me though and I thought I should share.

This includes changes made in #34 so merge that first if you like these changes too.
See my last comment in #32 for my motivation.
