### PR TITLE
Buffers blacklist

### DIFF
--- a/plugin/numbers.vim
+++ b/plugin/numbers.vim
@@ -25,6 +25,11 @@ if (!exists('g:enable_numbers'))
     let g:enable_numbers = 1
 endif
 
+if !exists('g:numbers_blacklist')
+  " some sane defaults for blacklisting
+  let g:numbers_blacklist = ['^NERD_tree_\d\+$', '^__Tagbar__$', '^__Gundo\(_Preview\)\?__$']
+endif
+
 if v:version < 703 || &cp
     echomsg "numbers.vim: you need at least Vim 7.3 and 'nocp' set"
     echomsg "Failed loading numbers.vim"
@@ -87,19 +92,27 @@ function! Uncenter()
     call ResetNumbers()
 endfunc
 
+function! NumbersCheck(func)
+  " decotrator for executing au commands only if buffer is not on blacklist
+  let bufname = bufname('%')
+  if empty(filter(copy(g:numbers_blacklist), 'match(bufname, v:val) != -1'))
+    call function(a:func)()
+  endif
+endfunction
+
 function! NumbersEnable()
     let g:enable_numbers = 1
     :set relativenumber
     augroup enable
         au!
-        autocmd InsertEnter * :call SetNumbers()
-        autocmd InsertLeave * :call SetRelative()
-        autocmd BufNewFile  * :call ResetNumbers()
-        autocmd BufReadPost * :call ResetNumbers()
-        autocmd FocusLost   * :call Uncenter()
-        autocmd FocusGained * :call Center()
-        autocmd WinEnter    * :call SetRelative()
-        autocmd WinLeave    * :call SetNumbers()
+        autocmd InsertEnter * :call NumbersCheck('SetNumbers')
+        autocmd InsertLeave * :call NumbersCheck('SetRelative')
+        autocmd BufNewFile  * :call NumbersCheck('ResetNumbers')
+        autocmd BufReadPost * :call NumbersCheck('ResetNumbers')
+        autocmd FocusLost   * :call NumbersCheck('Uncenter')
+        autocmd FocusGained * :call NumbersCheck('Center')
+        autocmd WinEnter    * :call NumbersCheck('SetRelative')
+        autocmd WinLeave    * :call NumbersCheck('SetNumbers')
     augroup END
 endfunc
 


### PR DESCRIPTION
In autocommands there's a check for buffer name. If it is blacklisted then nothing is done, in other case it'll execute given function. See issue #39
