### PR TITLE
Remind people to use set number

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,10 @@ may want to add mappings in your `.vimrc` for some of the commands, e.g.,
     nnoremap <F3> :NumbersToggle<CR>
     nnoremap <F4> :NumbersOnOff<CR>
 
-You may also wish to add `set number` as well, if you wish to turn line numbering on by default.
+Vim 7.4
+-------
+If you are lucky enough to be a Vim 7.4 user, you may experience unexpected
+behaviour if `set number` is not present in your `~/.vimrc`.
 
 [p]: https://github.com/tpope/vim-pathogen
 [v]: https://github.com/gmarik/vundle


### PR DESCRIPTION
`NumbersToggle` works without `set number`, which gives some rather unexpected behaviour. Remind people to turn line numbering on by default.
