### PR TITLE
Support excluding buffers by name, to support Buffergator and fix #48

### DIFF
--- a/plugin/numbers.vim
+++ b/plugin/numbers.vim
@@ -26,7 +26,7 @@ if (!exists('g:enable_numbers'))
 endif
 
 if (!exists('g:numbers_exclude'))
-    let g:numbers_exclude = ['unite', 'tagbar', 'startify', 'gundo', 'vimshell', 'w3m', 'nerdtree']
+    let g:numbers_exclude = ['unite', 'tagbar', 'startify', 'gundo', 'vimshell', 'w3m', 'nerdtree', "[[buffergator-buffers]]"]
 endif
 
 if v:version < 703 || &cp
@@ -79,7 +79,7 @@ function! ResetNumbers()
     else
         call NumbersRelativeOff()
     end
-    if index(g:numbers_exclude, &ft) >= 0
+    if index(g:numbers_exclude, &ft) >= 0 || index(g:numbers_exclude, @%) >= 0
         setlocal norelativenumber
         setlocal nonumber
     endif


### PR DESCRIPTION
This pull request changes how numbers.vim checks buffers against g:numbers_exclude.

Previously, buffers were only checked by their filetype against g:numbers_exclude. This meant plugins like Buffergator, which don't set the filetype of their buffers, could not be excluded, as detailed in #48.

numbers.vim now checks buffers by both filetype and name against g:numbers_exclude. It also adds "[[buffergator-buffers]]" (the name of Buffergator buffers) to the default value of g:numbers_exclude.

These two changes now means numbers.vim plays nicely with Buffergator, and similar plugins.
