### PR TITLE
Preserve original 'set number' if filetype in exclusion list

### DIFF
--- a/plugin/numbers.vim
+++ b/plugin/numbers.vim
@@ -16,6 +16,11 @@
 
 let s:numbers_version = '0.5.0'
 
+let s:original_numbers = 0
+if &g:number == 1
+    let s:original_numbers = 1
+endif
+
 if exists("g:loaded_numbers") && g:loaded_numbers
     finish
 endif
@@ -80,8 +85,12 @@ function! ResetNumbers()
         call NumbersRelativeOff()
     end
     if index(g:numbers_exclude, &ft) >= 0
+        if s:original_numbers == 0
+            setlocal nonumber
+        else
+            setlocal number
+        end
         setlocal norelativenumber
-        setlocal nonumber
     endif
 endfunc
 


### PR DESCRIPTION
When I added 'set number' and excluded nerdtree, tagbar and taglist, I found that my nerdtree have no line number  on default because of the exclusion.
So here I add some codes to preserve 'set number' effects when filetype is in exclusion list.
Already tested :D

PS: Also found another bug that if the nerdtree or tagbar has been set to 'autofocus' then the first time it appears the line number will not works as we expected, I'm trying to fix it now.
