### PR TITLE
fix bug for NumbersToggle after NumbersOnOff

### DIFF
--- a/plugin/numbers.vim
+++ b/plugin/numbers.vim
@@ -44,11 +44,11 @@ let s:mode=0
 let s:center=1
 
 function! NumbersRelativeOff()
+  let s:mode = 1
     if v:version > 703 || (v:version == 703 && has('patch1115'))
         set norelativenumber
-    else
-        set number
     endif
+  set number
 endfunction
 
 function! SetNumbers()
@@ -66,7 +66,6 @@ function! NumbersToggle()
         let s:mode = 0
         set relativenumber
     else
-        let s:mode = 1
         call NumbersRelativeOff()
     endif
 endfunc


### PR DESCRIPTION
When use 'NumbersToggle()' after 'NumbersOnOff()', 'NumbersToggle()' will not toggle between relative and absolute numbering, but toggle between set and unset number.
I think this may not an expected behavior. so, I do 'set number' after 'NumbersRelativeOff()'
and I think s:mode=0 has strong relationship between NumbersRelativeOff() so I put it in.
Besides, I didn't totally understand your codes, so I may miss some point of your design.