### PR TITLE
Fixed numbers at startup for Neovim

### DIFF
--- a/plugin/numbers.vim
+++ b/plugin/numbers.vim
@@ -101,7 +101,8 @@ endfunc
 
 function! NumbersEnable()
     let g:enable_numbers = 1
-    :set relativenumber
+    set relativenumber
+    set number
     augroup enable
         au!
         autocmd InsertEnter * :call SetNumbers()


### PR DESCRIPTION
When starting Neovim the numbers are not always correct, fixed now.