### PR TITLE
Fix number toggle state to use live `relativenumber` option [63]

### DIFF
--- a/plugin/numbers.vim
+++ b/plugin/numbers.vim
@@ -64,13 +64,15 @@ function! SetRelative()
     call ResetNumbers()
 endfunc
 
+" Branch on the live option, not s:mode: the cached mode disagrees with the
+" gutter whenever the plugin never enabled itself (g:enable_numbers = 0).
 function! NumbersToggle()
-    if (s:mode == 1)
-        let s:mode = 0
-        set relativenumber
-    else
+    if (&relativenumber)
         let s:mode = 1
         call NumbersRelativeOff()
+    else
+        let s:mode = 0
+        set relativenumber
     endif
 endfunc
 


### PR DESCRIPTION
## Summary
This change updates the number toggle logic to rely on Vim’s current `relativenumber` setting rather than the plugin’s cached mode state. This prevents the toggle from getting out of sync with the gutter when the plugin has not initialized itself.

## Changes Made
- Updated `NumbersToggle()` to branch on `&relativenumber` instead of `s:mode`
- Adjusted state updates so `s:mode` is set consistently with the actual toggle action
- Preserved existing behavior for switching relative numbers on and off while fixing stale state handling

## Files Modified
- `plugin/numbers.vim` — corrected toggle logic to use the live editor option state

## Important Notes
- This fixes a state mismatch that can occur when `g:enable_numbers = 0`, where the cached mode and displayed gutter could disagree
- No explicit tests were included in the diff; validation would typically involve manually toggling the plugin with `relativenumber` enabled/disabled and confirming the gutter state stays in sync

Fixes #63