### PR TITLE
Keep plain line numbers enabled when disabling contextual numbers [64]

### DIFF
--- a/doc/numbers.txt
+++ b/doc/numbers.txt
@@ -52,11 +52,16 @@ For convenience you may want to add a mapping for |:NumbersToggle| and
     Note that this toggles the kind of line numbers being shown -- it does not
     toggle the plugin itself. For that, see |:NumbersOnOff|.
 
+    The switch lasts until the next mode change or window switch, which puts
+    the contextual switching back in charge. To stay on plain |number| for
+    good, use |:NumbersDisable|.
+
 :NumbersEnable                                                *:NumbersEnable*
     Enable contextual |relativenumber| / |number| switching.
 
 :NumbersDisable                                              *:NumbersDisable*
-    Disable contextual |relativenumber| / |number| switching.
+    Disable contextual |relativenumber| / |number| switching, leaving plain
+    |number| line numbers.
 
 :NumbersOnOff                                                  *:NumbersOnOff*
     Toggle the status of contextual |relativenumber| / |number| switching.

--- a/plugin/numbers.vim
+++ b/plugin/numbers.vim
@@ -121,7 +121,7 @@ endfunc
 function! NumbersDisable()
     let g:enable_numbers = 0
     set norelativenumber
-    set nonumber
+    set number
     augroup enable
         au!
     augroup END


### PR DESCRIPTION
## Summary
This change updates the behavior of `:NumbersDisable` so it turns off contextual line number switching while leaving plain `number` enabled. The documentation is also updated to clarify that the contextual setting is temporary and will resume on mode or window changes unless explicitly disabled.

## Changes Made
- Changed `NumbersDisable()` to set `number` instead of `nonumber`
- Updated documentation for `:NumbersDisable` to reflect that it leaves plain line numbers on
- Added clarification that temporary switching lasts until the next mode or window change
- Updated help text for `:NumbersEnable` / `:NumbersDisable` behavior in `doc/numbers.txt`

## Files Modified
- `plugin/numbers.vim` — adjusts disable behavior to keep absolute line numbers enabled
- `doc/numbers.txt` — updates command documentation and usage notes

## Important Notes
- This is a behavior change for users relying on `:NumbersDisable`; after this change, disabling contextual switching will no longer hide line numbers entirely.
- No explicit test changes are included in the diff. It would be good to verify that `:NumbersDisable` preserves `number` and that contextual switching still resumes correctly after mode/window changes.

Fixes #64