### PR TITLE
Add configurable buftype exclusions for line numbers

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,16 +35,23 @@ a `:BundleInstall`:
 Numbers Don't Belong    
 --------------------
 
-If you see numbers where they don't belong like in the help menus or other vim plugins be sure to add your plugins to the excludes list in your vimrc like so
+If you see numbers where they don't belong like in the help menus or other vim plugins be sure to add the filetypes used by your plugins to the excludes list in your vimrc like so
 
     let g:numbers_exclude = ['tagbar', 'gundo', 'minibufexpl', 'nerdtree']
-    
+
 The plugin by default contains the following:
 
-    let g:numbers_exclude = ['unite', 'tagbar', 'startify', 'gundo', 'vimshell', 'w3m']$
-
+    let g:numbers_exclude = ['unite', 'tagbar', 'startify', 'gundo', 'vimshell', 'w3m', 'nerdtree', 'Mundo', 'MundoDiff']
 
 So be sure to include the superset in your vimrc or gvimrc
+
+Plugin windows often leave `filetype` empty, which puts them out of reach of
+that list. Those are excluded by `buftype` instead, which by default covers
+every special buffer kind:
+
+    let g:numbers_exclude_buftypes = ['acwrite', 'help', 'nofile', 'nowrite', 'popup', 'prompt', 'quickfix', 'terminal']
+
+Shorten that list if you want line numbers back in one of those windows.
 
 Usage
 -----

--- a/doc/numbers.txt
+++ b/doc/numbers.txt
@@ -36,6 +36,37 @@ following: >
     let g:enable_numbers = 0
 <
 
+                                                          *g:numbers_exclude*
+g:numbers_exclude~
+
+Default: ['unite', 'tagbar', 'startify', 'gundo', 'vimshell', 'w3m',
+          'nerdtree', 'Mundo', 'MundoDiff']
+
+Filetypes that should show no line numbers at all. If a plugin window shows
+numbers where they don't belong, add its 'filetype' to the list: >
+
+    let g:numbers_exclude = ['tagbar', 'gundo', 'minibufexpl', 'nerdtree']
+<
+Setting this replaces the default list rather than adding to it, so include
+the entries you still want.
+
+                                                 *g:numbers_exclude_buftypes*
+g:numbers_exclude_buftypes~
+
+Default: ['acwrite', 'help', 'nofile', 'nowrite', 'popup', 'prompt',
+          'quickfix', 'terminal']
+
+The same thing for 'buftype'. Terminal, help and quickfix windows are
+number-free in Vim and Neovim by default, and plugin windows frequently leave
+'filetype' empty, which puts them out of reach of |g:numbers_exclude|.
+
+The default covers every non-empty 'buftype'. Shorten the list to let numbers
+back into a kind of window -- for example, to keep them in the quickfix
+window: >
+
+    let g:numbers_exclude_buftypes = ['help', 'nofile', 'terminal']
+<
+
 For convenience you may want to add a mapping for |:NumbersToggle| and
 |:NumbersOnOff|. For example: >
 

--- a/plugin/numbers.vim
+++ b/plugin/numbers.vim
@@ -29,6 +29,13 @@ if (!exists('g:numbers_exclude'))
     let g:numbers_exclude = ['unite', 'tagbar', 'startify', 'gundo', 'vimshell', 'w3m', 'nerdtree', 'Mundo', 'MundoDiff']
 endif
 
+" Every non-empty 'buftype' in Vim and Neovim: these buffers are number-free by
+" default, and plugins that use them often leave 'filetype' empty, which puts
+" them out of reach of g:numbers_exclude.
+if (!exists('g:numbers_exclude_buftypes'))
+    let g:numbers_exclude_buftypes = ['acwrite', 'help', 'nofile', 'nowrite', 'popup', 'prompt', 'quickfix', 'terminal']
+endif
+
 if v:version < 703 || &cp
     echomsg "numbers.vim: you need at least Vim 7.3 and 'nocp' set"
     echomsg "Failed loading numbers.vim"
@@ -82,9 +89,7 @@ function! ResetNumbers()
     else
         call NumbersRelativeOff()
     end
-    " Special buffers (help, terminal, quickfix, nofile) are number-free by
-    " default; don't put numbers back into them.
-    if index(g:numbers_exclude, &ft) >= 0 || &buftype !=# ''
+    if index(g:numbers_exclude, &ft) >= 0 || index(g:numbers_exclude_buftypes, &bt) >= 0
         setlocal norelativenumber
         setlocal nonumber
     endif


### PR DESCRIPTION
## Summary
This change expands the plugin’s exclusion handling from filetypes alone to also cover buffer types. It adds a new configurable `g:numbers_exclude_buftypes` setting and updates the documentation to explain how plugin and special buffers are excluded from line numbers by default.

## Changes Made
- Added a new default configuration variable, `g:numbers_exclude_buftypes`, to define buffer types that should never show line numbers.
- Updated `ResetNumbers()` to suppress both `number` and `relativenumber` when the current buffer’s `filetype` or `buftype` is in the configured exclude lists.
- Corrected the README's stale copy of the default `g:numbers_exclude` list, which omitted `nerdtree`, `Mundo` and `MundoDiff` and carried a stray `$`. The plugin default itself is unchanged.
- Updated README documentation to clarify the difference between filetype-based and buftype-based exclusions.
- Added Vim help documentation for both `g:numbers_exclude` and `g:numbers_exclude_buftypes`.

## Files Modified
- `README.md` — Updated user-facing setup and exclusion guidance.
- `doc/numbers.txt` — Added help documentation for the new buftype exclusion setting and expanded defaults.
- `plugin/numbers.vim` — Introduced buftype exclusions and updated number-reset logic.

## Important Notes
- This is a behavior change for special/plugin buffers: buffers with excluded `buftype` values will now consistently remain number-free, even if their `filetype` is empty.
- Both exclusion variables replace the defaults when set in user config, so users should include any desired default entries when overriding them.
- No tests were included in the diff.

---

Builds on the `g:numbers_exclude_buftypes` idea from @akho in #75, which sat unreviewed since 2020. Differences from that PR:

- keeps `g:numbers_exclude` under its existing name (#75 renamed it to `g:numbers_exclude_filetypes`, which would have silently dropped every existing user's vimrc setting)
- default list also covers `popup` and `prompt`, so it spans every non-empty `buftype` in both Vim and Neovim
- documents both options in `doc/numbers.txt`, where `g:numbers_exclude` had never been documented at all

Verified on nvim 0.12.4 and vim 9.2: terminal, help and quickfix windows stay number-free by default, and shortening the list lets numbers back into the quickfix window on both editors.
