### PR TITLE
Add buffer plugin filetypes to excluded number list [55,48,59]

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ If you see numbers where they don't belong like in the help menus or other vim p
 
 The plugin by default contains the following:
 
-    let g:numbers_exclude = ['unite', 'tagbar', 'startify', 'gundo', 'vimshell', 'w3m', 'nerdtree', 'Mundo', 'MundoDiff']
+    let g:numbers_exclude = ['unite', 'tagbar', 'startify', 'gundo', 'vimshell', 'w3m', 'nerdtree', 'Mundo', 'MundoDiff', 'buffergator', 'easybuffer']
 
 So be sure to include the superset in your vimrc or gvimrc
 

--- a/doc/numbers.txt
+++ b/doc/numbers.txt
@@ -40,7 +40,7 @@ following: >
 g:numbers_exclude~
 
 Default: ['unite', 'tagbar', 'startify', 'gundo', 'vimshell', 'w3m',
-          'nerdtree', 'Mundo', 'MundoDiff']
+          'nerdtree', 'Mundo', 'MundoDiff', 'buffergator', 'easybuffer']
 
 Filetypes that should show no line numbers at all. If a plugin window shows
 numbers where they don't belong, add its 'filetype' to the list: >

--- a/plugin/numbers.vim
+++ b/plugin/numbers.vim
@@ -26,7 +26,7 @@ if (!exists('g:enable_numbers'))
 endif
 
 if (!exists('g:numbers_exclude'))
-    let g:numbers_exclude = ['unite', 'tagbar', 'startify', 'gundo', 'vimshell', 'w3m', 'nerdtree', 'Mundo', 'MundoDiff']
+    let g:numbers_exclude = ['unite', 'tagbar', 'startify', 'gundo', 'vimshell', 'w3m', 'nerdtree', 'Mundo', 'MundoDiff', 'buffergator', 'easybuffer']
 endif
 
 " Every non-empty 'buftype' in Vim and Neovim: these buffers are number-free by
@@ -118,10 +118,17 @@ function! NumbersEnable()
         autocmd InsertLeave * :call SetRelative()
         autocmd BufNewFile  * :call ResetNumbers()
         autocmd BufReadPost * :call ResetNumbers()
+        " Plugin windows often set 'filetype' after BufNewFile has already
+        " fired, so re-check the exclude list once it is actually set.
+        autocmd FileType    * :call ResetNumbers()
         autocmd FocusLost   * :call Uncenter()
         autocmd FocusGained * :call Center()
         autocmd WinEnter    * :call SetRelative()
         autocmd WinLeave    * :call SetNumbers()
+        " Vim leaves numbers in a terminal window until it is re-entered.
+        if exists('##TerminalOpen')
+            autocmd TerminalOpen * :call ResetNumbers()
+        endif
     augroup END
 endfunc
 


### PR DESCRIPTION
## Summary
This change updates the default `g:numbers_exclude` list to cover additional plugin windows and improves event handling so line numbers are reset more reliably when filetypes are assigned late. It also adds terminal-specific handling to avoid line numbers persisting in terminal buffers in supported Vim versions.

## Changes Made
- Added `buffergator` and `easybuffer` to the default `g:numbers_exclude` list in:
  - `README.md`
  - `doc/numbers.txt`
  - `plugin/numbers.vim`
- Added a `FileType` autocmd to re-run number reset logic after plugin windows assign their filetype.
- Added conditional `TerminalOpen` autocmd support to reset numbers when entering terminal buffers on Vim versions that expose that event.

## Files Modified
- `README.md` — Updated the documented default excluded filetypes.
- `doc/numbers.txt` — Updated the plugin help documentation for `g:numbers_exclude`.
- `plugin/numbers.vim` — Updated the default exclude list and added autocmds for `FileType` and `TerminalOpen`.

## Important Notes
- The new `TerminalOpen` handling is conditional on `exists('##TerminalOpen')`, so it only applies in Vim builds that support that event.
- No tests were included in the diff. If available, it would be worth validating:
  - plugin windows that set `filetype` after buffer creation
  - terminal buffers retaining/removing line numbers as expected
  - default behavior when `g:numbers_exclude` is overridden in user config

Fixes #55
Fixes #48
Fixes #59