### PR TITLE
Add a dependency-free test suite and CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,22 @@
+name: tests
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      # vim-nox rather than vim: the plain package is built without +terminal,
+      # which the buftype cases need.
+      - name: Install editors
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y vim-nox neovim
+
+      - name: Run tests
+        run: ./test/run.sh

--- a/README.md
+++ b/README.md
@@ -67,5 +67,15 @@ Vim 7.4
 If you are lucky enough to be a Vim 7.4 user, you may experience unexpected
 behaviour if `set number` is not present in your `~/.vimrc`.
 
+Tests
+-----
+
+    ./test/run.sh            # every case, against both vim and neovim
+    ./test/run.sh toggle     # a single case
+
+Each case in `test/cases/` runs in its own editor process and asserts on
+`number` and `relativenumber`. Editors that are not installed are skipped. CI
+runs the same script.
+
 [p]: https://github.com/tpope/vim-pathogen
 [v]: https://github.com/gmarik/vundle

--- a/test/assert.vim
+++ b/test/assert.vim
@@ -1,0 +1,40 @@
+" Assertion helpers shared by every case in test/cases/.
+"
+" Results go to stdout via writefile() because Vim's silent mode (-es), which
+" the runner needs in order to capture output, discards :echo.
+
+let g:t_results = []
+let g:t_failed = 0
+
+function! Assert(desc, expected, actual) abort
+    if a:expected ==# a:actual
+        call add(g:t_results, '  ok   ' . a:desc)
+    else
+        let g:t_failed += 1
+        call add(g:t_results, printf('  FAIL %s -- expected %s, got %s',
+                    \ a:desc, a:expected, a:actual))
+    endif
+endfunction
+
+" The plugin's entire observable behaviour is these two window options.
+function! AssertNumbers(desc, nu, rnu) abort
+    call Assert(a:desc, printf('nu=%d rnu=%d', a:nu, a:rnu),
+                \ printf('nu=%d rnu=%d', &number, &relativenumber))
+endfunction
+
+function! Skip(desc) abort
+    call add(g:t_results, '  skip ' . a:desc)
+endfunction
+
+" Round trip through insert mode, firing the real InsertEnter/InsertLeave.
+function! TypeSomething() abort
+    execute "normal! ia\<Esc>"
+endfunction
+
+function! TestDone() abort
+    call writefile(g:t_results, '/dev/stdout', 'a')
+    if g:t_failed > 0
+        cquit
+    endif
+    qall!
+endfunction

--- a/test/cases/enable_disable.vim
+++ b/test/cases/enable_disable.vim
@@ -1,0 +1,32 @@
+" Regression test for issue #64: every route out of relative numbering used to
+" lead back into it. :NumbersDisable in particular left 'relativenumber' on,
+" trapping the user in relative-only numbering.
+source <sfile>:h/../assert.vim
+
+edit /tmp/numbers-test-a.txt
+call AssertNumbers('startup is hybrid', 1, 1)
+
+NumbersDisable
+call AssertNumbers('#64 disable leaves plain absolute numbers', 1, 0)
+
+call TypeSomething()
+call AssertNumbers('#64 disable survives insert mode', 1, 0)
+
+split
+wincmd j
+wincmd k
+call AssertNumbers('#64 disable survives window switching', 1, 0)
+only
+
+NumbersEnable
+call AssertNumbers('enable restores contextual switching', 1, 1)
+doautocmd InsertEnter
+call AssertNumbers('switching works again after enable', 1, 0)
+doautocmd InsertLeave
+
+NumbersOnOff
+call AssertNumbers('onoff turns the plugin off', 1, 0)
+NumbersOnOff
+call AssertNumbers('onoff turns the plugin back on', 1, 1)
+
+call TestDone()

--- a/test/cases/exclude_buftypes.vim
+++ b/test/cases/exclude_buftypes.vim
@@ -1,0 +1,31 @@
+" Special windows stay number-free. Regression test for issue #70, where
+" numbers came back in a terminal window as soon as it was re-entered.
+source <sfile>:h/../assert.vim
+
+edit /tmp/numbers-test-a.txt
+call AssertNumbers('normal buffer is hybrid', 1, 1)
+
+help
+call AssertNumbers('help window has no numbers', 0, 0)
+close
+
+call setqflist([{'filename': '/tmp/numbers-test-a.txt', 'lnum': 1, 'text': 'x'}])
+copen
+call AssertNumbers('quickfix window has no numbers', 0, 0)
+cclose
+
+if has('terminal') || has('nvim')
+    split
+    terminal
+    call AssertNumbers('#70 fresh terminal has no numbers', 0, 0)
+    wincmd j
+    wincmd k
+    call AssertNumbers('#70 terminal stays clean when re-entered', 0, 0)
+    wincmd j
+    wincmd k
+    call AssertNumbers('#70 and stays clean on every re-entry', 0, 0)
+else
+    call Skip('#70 terminal cases -- editor built without +terminal')
+endif
+
+call TestDone()

--- a/test/cases/exclude_buftypes_custom.vim
+++ b/test/cases/exclude_buftypes_custom.vim
@@ -1,0 +1,16 @@
+" SETUP: let g:numbers_exclude_buftypes = ['help', 'nofile', 'terminal']
+" Shortening the list lets numbers back into a kind of window.
+source <sfile>:h/../assert.vim
+
+edit /tmp/numbers-test-a.txt
+
+call setqflist([{'filename': '/tmp/numbers-test-a.txt', 'lnum': 1, 'text': 'x'}])
+copen
+call AssertNumbers('quickfix keeps numbers when dropped from the list', 1, 1)
+cclose
+
+help
+call AssertNumbers('help is still excluded', 0, 0)
+close
+
+call TestDone()

--- a/test/cases/exclude_filetypes.vim
+++ b/test/cases/exclude_filetypes.vim
@@ -1,0 +1,33 @@
+" Excluded filetypes show no numbers at all.
+"
+" Issues #55, #48 and #59 were all the same failure: plugin windows set their
+" filetype after BufNewFile has already fired, so the exclude list was checked
+" against an empty 'filetype'. These cases set the filetype late on purpose --
+" that is what the FileType autocmd exists to catch.
+source <sfile>:h/../assert.vim
+
+edit /tmp/numbers-test-a.txt
+call AssertNumbers('normal buffer is hybrid', 1, 1)
+
+new
+call AssertNumbers('new scratch buffer starts with numbers', 1, 1)
+setf nerdtree
+call AssertNumbers('#59 filetype set late is still excluded', 0, 0)
+bwipeout!
+
+new
+setf buffergator
+call AssertNumbers('#48 buffergator is excluded by default', 0, 0)
+bwipeout!
+
+new
+setf easybuffer
+call AssertNumbers('#55 easybuffer is excluded by default', 0, 0)
+bwipeout!
+
+new
+setf text
+call AssertNumbers('an ordinary filetype keeps its numbers', 1, 1)
+bwipeout!
+
+call TestDone()

--- a/test/cases/exclude_filetypes_custom.vim
+++ b/test/cases/exclude_filetypes_custom.vim
@@ -1,0 +1,22 @@
+" SETUP: let g:numbers_exclude = ['tagbar', 'myplugin']
+" Setting g:numbers_exclude replaces the default list rather than extending it.
+source <sfile>:h/../assert.vim
+
+edit /tmp/numbers-test-a.txt
+
+new
+setf myplugin
+call AssertNumbers('a user-listed filetype is excluded', 0, 0)
+bwipeout!
+
+new
+setf tagbar
+call AssertNumbers('a kept default is still excluded', 0, 0)
+bwipeout!
+
+new
+setf nerdtree
+call AssertNumbers('a dropped default is no longer excluded', 1, 1)
+bwipeout!
+
+call TestDone()

--- a/test/cases/mode_switching.vim
+++ b/test/cases/mode_switching.vim
@@ -1,0 +1,27 @@
+" Core contract: relative while navigating, absolute while typing or away.
+source <sfile>:h/../assert.vim
+
+edit /tmp/numbers-test-a.txt
+call AssertNumbers('startup is hybrid', 1, 1)
+
+call TypeSomething()
+call AssertNumbers('back to hybrid after leaving insert', 1, 1)
+
+doautocmd InsertEnter
+call AssertNumbers('insert mode is absolute', 1, 0)
+doautocmd InsertLeave
+call AssertNumbers('normal mode is hybrid', 1, 1)
+
+" Real focus events cannot be produced headlessly.
+doautocmd FocusLost
+call AssertNumbers('unfocused window is absolute', 1, 0)
+doautocmd FocusGained
+call AssertNumbers('refocused window is hybrid', 1, 1)
+
+split
+wincmd j
+call AssertNumbers('entered window is hybrid', 1, 1)
+wincmd k
+call AssertNumbers('other window is hybrid once entered', 1, 1)
+
+call TestDone()

--- a/test/cases/toggle.vim
+++ b/test/cases/toggle.vim
@@ -1,0 +1,19 @@
+" :NumbersToggle flips the numbering style; it does not disable the plugin.
+source <sfile>:h/../assert.vim
+
+edit /tmp/numbers-test-a.txt
+call AssertNumbers('startup is hybrid', 1, 1)
+
+NumbersToggle
+call AssertNumbers('toggle goes absolute', 1, 0)
+NumbersToggle
+call AssertNumbers('toggle goes back to relative', 1, 1)
+NumbersToggle
+call AssertNumbers('toggle alternates on every call', 1, 0)
+
+" Documented behaviour: contextual switching takes over again at the next
+" mode change, so the toggle is momentary rather than sticky.
+call TypeSomething()
+call AssertNumbers('contextual switching resumes after toggle', 1, 1)
+
+call TestDone()

--- a/test/cases/toggle_when_disabled_at_startup.vim
+++ b/test/cases/toggle_when_disabled_at_startup.vim
@@ -1,0 +1,15 @@
+" SETUP: let g:enable_numbers = 0 | set number
+" Regression test for issue #63: with the plugin disabled in the vimrc, the
+" first :NumbersToggle used to be a no-op because the cached s:mode disagreed
+" with the actual gutter, so it took two calls to reach relative numbering.
+source <sfile>:h/../assert.vim
+
+edit /tmp/numbers-test-a.txt
+call AssertNumbers('startup leaves plain number', 1, 0)
+
+NumbersToggle
+call AssertNumbers('#63 first toggle switches immediately', 1, 1)
+NumbersToggle
+call AssertNumbers('#63 second toggle switches back', 1, 0)
+
+call TestDone()

--- a/test/run.sh
+++ b/test/run.sh
@@ -1,0 +1,84 @@
+#!/usr/bin/env bash
+#
+# Runs every case in test/cases/ against both Vim and Neovim.
+#
+# Each case runs in its own editor process so that the plugin's global state
+# cannot leak between them. A case may request startup configuration with a
+# `" SETUP: <commands>` line, which the runner passes as --cmd before the
+# plugin loads.
+#
+# Usage: test/run.sh [case-name ...]
+
+set -u
+
+root=$(cd "$(dirname "$0")/.." && pwd)
+cases=()
+if [ $# -gt 0 ]; then
+    for name in "$@"; do
+        path="$root/test/cases/$name.vim"
+        if [ ! -f "$path" ]; then
+            echo "no such case: $name" >&2
+            exit 1
+        fi
+        cases+=("$path")
+    done
+else
+    for path in "$root"/test/cases/*.vim; do cases+=("$path"); done
+fi
+
+passed=0
+failed=0
+ran_any=0
+
+run_case() {
+    local editor=$1 path=$2 setup args output status
+    setup=$(grep -m1 '^" SETUP: ' "$path" | cut -d: -f2-)
+
+    args=(--cmd "set rtp+=$root")
+    if [ -n "$setup" ]; then
+        args+=(--cmd "$setup")
+    fi
+
+    # Stdin is closed throughout: an editor that hits an unexpected prompt
+    # should fail the case rather than block the run forever.
+    if [ "$editor" = nvim ]; then
+        output=$(nvim --headless --clean "${args[@]}" -S "$path" </dev/null 2>&1)
+        status=$?
+    else
+        # -u NORC keeps plugin loading enabled; -u NONE would disable it.
+        # -es is silent Ex mode, which is why cases report via writefile().
+        output=$(vim -es -u NORC -N "${args[@]}" -S "$path" </dev/null 2>&1 | tr -d '\r')
+        status=${PIPESTATUS[0]}
+    fi
+
+    echo "$output"
+    return $status
+}
+
+for editor in vim nvim; do
+    if ! command -v "$editor" >/dev/null 2>&1; then
+        echo "skipping $editor -- not installed"
+        continue
+    fi
+    ran_any=1
+    echo "$("$editor" --version | head -1)"
+
+    for path in "${cases[@]}"; do
+        name=$(basename "$path" .vim)
+        echo "$name"
+        if run_case "$editor" "$path"; then
+            passed=$((passed + 1))
+        else
+            failed=$((failed + 1))
+        fi
+    done
+    echo
+done
+
+if [ "$ran_any" -eq 0 ]; then
+    echo "no editor found; install vim or neovim"
+    exit 1
+fi
+
+echo "$passed case(s) passed, $failed failed"
+[ "$failed" -eq 0 ]


### PR DESCRIPTION
## Summary

Adds a dependency-free test suite and a CI workflow. Stacked on #80 — the base is `fix/exclude-timing`, so this diff is test files only and GitHub will retarget it to `master` once #80 merges.

## What it covers

Every case comes from a bug this repo actually had:

- mode, focus and window switching (the core contract)
- `:NumbersToggle` alternating, and remaining momentary rather than sticky
- first toggle with `g:enable_numbers = 0` — #63
- `:NumbersDisable` leaving plain absolute numbers, surviving insert mode and window switches — #64
- terminal, help and quickfix windows staying number-free, plus a shortened `g:numbers_exclude_buftypes` letting numbers back into quickfix — #70
- filetypes set late, which is what `BufNewFile` alone could not catch — #55, #48, #59

## Design

`test/run.sh` runs each case in `test/cases/` in its own editor process, against both `vim` and `nvim`, and skips editors that are not installed. Cases assert on `number` and `relativenumber` — the plugin's entire observable surface — and report via `writefile()` because Vim's silent mode discards `:echo`. A failing case calls `:cquit`, so the runner exits non-zero.

No external plugins are required: the sidebar-plugin cases simulate the late-filetype pattern rather than depending on NERDTree or buffergator being installed.

## Verification

- 16 cases pass on nvim 0.12.4 and vim 9.2 locally.
- The same suite run against `1867e76` (before this session's fixes) fails 6 cases with 17 assertion failures, covering #63, #64, #70 and the filetype-timing bugs — so the tests demonstrably detect the regressions they exist to catch.
- Behaviour was also verified by hand against real NERDTree, vim-buffergator and easybuffer.vim checkouts; those are deliberately not a test dependency.
