### PR TITLE
Handle terminal open events in both Vim and Neovim

### DIFF
--- a/plugin/numbers.vim
+++ b/plugin/numbers.vim
@@ -125,9 +125,14 @@ function! NumbersEnable()
         autocmd FocusGained * :call Center()
         autocmd WinEnter    * :call SetRelative()
         autocmd WinLeave    * :call SetNumbers()
-        " Vim leaves numbers in a terminal window until it is re-entered.
+        " Opening a terminal enters no window, so nothing above fires and the
+        " numbers linger until it is left and re-entered. Vim and Neovim spell
+        " the event differently.
         if exists('##TerminalOpen')
             autocmd TerminalOpen * :call ResetNumbers()
+        endif
+        if exists('##TermOpen')
+            autocmd TermOpen * :call ResetNumbers()
         endif
     augroup END
 endfunc


### PR DESCRIPTION
## Summary
This change improves terminal buffer handling in the numbers plugin by resetting line numbers when a terminal is opened. It now supports both Vim and Neovim event names, ensuring numbers do not linger in terminal windows across editors.

## Changes Made
- Updated the terminal-related autocmd logic in `NumbersEnable()`
- Added support for both `TerminalOpen` and `TermOpen` events
- Kept the existing behavior of resetting numbers when terminal buffers are entered, left, or focused
- Clarified the comment describing why terminal-specific handling is needed

## Files Modified
- `plugin/numbers.vim` — Added Neovim-compatible terminal open event handling and updated the related comment

## Important Notes
- This change improves compatibility between Vim and Neovim terminal events.
- No breaking changes are expected.
- Testing was not included in the diff; manual verification in both Vim and Neovim terminals would be advisable.