### PR TITLE
Fix relative numbers during Insert mode Ctrl-O commands [45]

### DIFF
--- a/plugin/numbers.vim
+++ b/plugin/numbers.vim
@@ -71,6 +71,18 @@ function! SetRelative()
     call ResetNumbers()
 endfunc
 
+" i_CTRL-O runs a single command in normal mode, firing InsertLeave and
+" InsertEnter around it. Switching for that round trip flips the numbers twice
+" while the user never really left insert mode. mode() reports the pending
+" state as niI, niR or niV; older Vims report neither and keep the old
+" behaviour.
+function! LeaveInsert()
+    if mode(1) =~# '^ni'
+        return
+    endif
+    call SetRelative()
+endfunc
+
 " Branch on the live option, not s:mode: the cached mode disagrees with the
 " gutter whenever the plugin never enabled itself (g:enable_numbers = 0).
 function! NumbersToggle()
@@ -115,7 +127,7 @@ function! NumbersEnable()
     augroup enable
         au!
         autocmd InsertEnter * :call SetNumbers()
-        autocmd InsertLeave * :call SetRelative()
+        autocmd InsertLeave * :call LeaveInsert()
         autocmd BufNewFile  * :call ResetNumbers()
         autocmd BufReadPost * :call ResetNumbers()
         " Plugin windows often set 'filetype' after BufNewFile has already

--- a/test/cases/insert_ctrl_o.vim
+++ b/test/cases/insert_ctrl_o.vim
@@ -1,0 +1,31 @@
+" Regression test for issue #45: i_CTRL-O runs one normal-mode command from
+" insert mode, firing InsertLeave and InsertEnter around it. The numbers used
+" to flip to relative and straight back, which is very visible for anyone with
+" insert-mode mappings built on <C-o>.
+source <sfile>:h/../assert.vim
+
+edit /tmp/numbers-test-a.txt
+
+" Sampled after the plugin's own handler, since this autocmd is defined later.
+let g:samples = []
+augroup sample
+    au!
+    autocmd InsertLeave * call add(g:samples, &relativenumber)
+augroup END
+
+if has('nvim') || has('gui_running')
+    execute "normal! i\<C-o>whello\<Esc>"
+
+    call Assert('#45 numbers stay absolute across CTRL-O',
+                \ 'rnu=0', 'rnu=' . g:samples[0])
+    call Assert('the real insert exit still restores relative',
+                \ 'rnu=1', 'rnu=' . g:samples[-1])
+    call AssertNumbers('and the window ends up hybrid', 1, 1)
+else
+    " Vim's silent Ex mode reports mode() as "ce" regardless of the real mode,
+    " so the insert-pending state cannot be observed here. Verified by hand
+    " under a pty instead: vim 9.2 reports niI exactly like Neovim.
+    call Skip('#45 CTRL-O -- mode() is not meaningful in silent Ex mode')
+endif
+
+call TestDone()


### PR DESCRIPTION
## Summary
This change prevents the numbers plugin from briefly switching to relative numbering when a single Normal-mode command is run via `Ctrl-O` from Insert mode. It adds a mode check to distinguish true Insert mode exit from insert-pending states, and includes a regression test covering the `i_CTRL-O` behavior.

## Changes Made
- Added a new `LeaveInsert()` helper in `plugin/numbers.vim` to detect insert-pending modes (`niI`, `niR`, `niV`) and avoid changing number settings during `Ctrl-O` command execution.
- Updated the `InsertLeave` autocmd to call `LeaveInsert()` instead of directly switching to relative numbers.
- Added a regression test for issue #45 that verifies:
  - relative numbering does not toggle during `i_CTRL-O`
  - relative numbering is restored on the actual insert-mode exit
  - the window ends in the expected hybrid number state

## Files Modified
- `plugin/numbers.vim` — Adds insert-pending mode handling and updates the insert leave autocmd behavior.
- `test/cases/insert_ctrl_o.vim` — New regression test for `Ctrl-O` behavior from Insert mode.

## Important Notes
- This change relies on `mode(1)` to detect the insert-pending states introduced by `Ctrl-O`; older Vim versions that do not report these states will retain the previous behavior.
- The new test is skipped in Vim silent Ex mode because `mode()` is not reliable there; the behavior is noted as verified manually under a pty for Vim.
- No logging-related changes are included in this summary.

Fixes #45