### PR TITLE
Skip numbers plugin under vscode-neovim [76]

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,18 @@ Vim 7.4
 If you are lucky enough to be a Vim 7.4 user, you may experience unexpected
 behaviour if `set number` is not present in your `~/.vimrc`.
 
+VSCode
+------
+
+Under the [vscode-neovim][vn] extension the plugin disables itself. VSCode draws
+its own gutter, so switching `number` and `relativenumber` in Neovim has no
+effect on screen there, and it used to shift the cursor several columns to the
+right when entering insert mode.
+
+VSCode has the same feature built in:
+
+    "editor.lineNumbers": "relative"
+
 Tests
 -----
 
@@ -77,5 +89,6 @@ Each case in `test/cases/` runs in its own editor process and asserts on
 `number` and `relativenumber`. Editors that are not installed are skipped. CI
 runs the same script.
 
+[vn]: https://github.com/vscode-neovim/vscode-neovim
 [p]: https://github.com/tpope/vim-pathogen
 [v]: https://github.com/gmarik/vundle

--- a/doc/numbers.txt
+++ b/doc/numbers.txt
@@ -22,6 +22,10 @@ or not the app has focus.
 Commands are included for toggling the line numbering method and for enabling
 and disabling the plugin.
 
+Under the vscode-neovim extension the plugin disables itself: VSCode draws its
+own gutter, so there is nothing for it to switch. Use VSCode's own
+"editor.lineNumbers": "relative" setting instead.
+
 ==============================================================================
 2. CONFIGURATION                                       *numbers-configuration*
 

--- a/plugin/numbers.vim
+++ b/plugin/numbers.vim
@@ -19,6 +19,14 @@ let s:numbers_version = '0.5.0'
 if exists("g:loaded_numbers") && g:loaded_numbers
     finish
 endif
+
+" Under vscode-neovim the gutter belongs to VSCode, which draws its own line
+" numbers. Switching them here changes nothing on screen and shifts the
+" extension's cursor position, so there is nothing worth doing.
+if exists('g:vscode')
+    finish
+endif
+
 let g:loaded_numbers = 1
 
 if (!exists('g:enable_numbers'))

--- a/test/cases/vscode_neovim.vim
+++ b/test/cases/vscode_neovim.vim
@@ -1,0 +1,18 @@
+" SETUP: let g:vscode = 1
+" Regression test for issue #76: under the vscode-neovim extension, toggling
+" the numbers moved the cursor several columns right on entering insert mode.
+" VSCode renders its own gutter, so the plugin stays out of the way entirely.
+source <sfile>:h/../assert.vim
+
+edit /tmp/numbers-test-a.txt
+
+call Assert('#76 the plugin does not load under vscode-neovim',
+            \ 'loaded=0', 'loaded=' . exists('g:loaded_numbers'))
+call AssertNumbers('#76 the gutter is left exactly as VSCode set it', 0, 0)
+
+doautocmd InsertEnter
+call AssertNumbers('#76 entering insert mode changes nothing', 0, 0)
+doautocmd InsertLeave
+call AssertNumbers('#76 leaving insert mode changes nothing', 0, 0)
+
+call TestDone()


### PR DESCRIPTION
## Summary
This change makes the `numbers` plugin opt out when running under the `vscode-neovim` extension. Since VSCode handles its own gutter and line numbers, the plugin no longer attempts to toggle `number`/`relativenumber` in that environment, preventing cursor offset issues in insert mode.

The documentation is updated to explain the behavior and direct users to VSCode’s built-in relative line number setting.

## Changes Made
- Added an early exit in `plugin/numbers.vim` when `g:vscode` is present.
- Documented the vscode-neovim behavior in `doc/numbers.txt`.
- Added a README section explaining that the plugin disables itself under VSCode/ vscode-neovim and linking to the extension.
- Added a regression test covering the vscode-neovim environment and verifying that line-number state remains unchanged.

## Files Modified
- `plugin/numbers.vim` — skips plugin initialization under vscode-neovim.
- `doc/numbers.txt` — adds configuration/docs note for VSCode users.
- `README.md` — adds a VSCode usage note and extension link.
- `test/cases/vscode_neovim.vim` — adds regression coverage for the vscode-neovim case.

## Important Notes
- This is a behavior change only for environments where `g:vscode` is set.
- Users of `vscode-neovim` should rely on VSCode’s `"editor.lineNumbers": "relative"` setting instead of this plugin.
- The new test covers the expected no-op behavior in VSCode mode, but no additional runtime dependencies are introduced.

Fixes #76