### PR TITLE
Improve command-line number behavior and harden test runner [62]

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,11 @@ absolute numbering (`number`) for the active window depending on the mode
 you are in. In a GUI, it also functions based on whether or not the app has
 focus.
 
+Numbers go absolute while you are in insert mode, while you are typing an Ex
+command (so the line in `:14y` can be read off the gutter), in inactive
+windows, and while the editor is unfocused. They are relative the rest of the
+time.
+
 Commands are included for toggling the line numbering method and for enabling
 and disabling the plugin.
 

--- a/doc/numbers.txt
+++ b/doc/numbers.txt
@@ -19,6 +19,11 @@ The |numbers| plugin intelligently alternates between relative numbering
 depending on the mode you are in. In a GUI, it also functions based on whether
 or not the app has focus.
 
+Numbers are absolute while you are in insert mode, while you are typing an Ex
+command -- so the line in :14y can be read straight off the gutter -- in
+inactive windows, and while the editor is unfocused. They are relative the
+rest of the time.
+
 Commands are included for toggling the line numbering method and for enabling
 and disabling the plugin.
 

--- a/plugin/numbers.vim
+++ b/plugin/numbers.vim
@@ -145,6 +145,14 @@ function! NumbersEnable()
         autocmd FocusGained * :call Center()
         autocmd WinEnter    * :call SetRelative()
         autocmd WinLeave    * :call SetNumbers()
+        " Ex commands address absolute lines, so :14y should be able to read
+        " line 14 off the gutter. Only the : command line: searches take no
+        " line numbers, and switching for them would just be flicker. The
+        " redraw is needed because opening the command line does not cause one.
+        if exists('##CmdlineEnter')
+            autocmd CmdlineEnter : :call SetNumbers() | redraw
+            autocmd CmdlineLeave : :call SetRelative()
+        endif
         " Opening a terminal enters no window, so nothing above fires and the
         " numbers linger until it is left and re-entered. Vim and Neovim spell
         " the event differently.

--- a/test/assert.vim
+++ b/test/assert.vim
@@ -3,6 +3,9 @@
 " Results go to stdout via writefile() because Vim's silent mode (-es), which
 " the runner needs in order to capture output, discards :echo.
 
+" Cases edit throwaway files in /tmp; swapfiles only produce noisy warnings.
+set noswapfile
+
 let g:t_results = []
 let g:t_failed = 0
 
@@ -31,7 +34,10 @@ function! TypeSomething() abort
     execute "normal! ia\<Esc>"
 endfunction
 
+" The runner treats a missing "done" line as a failure: a case that dies
+" partway through would otherwise exit 0 and be counted as a pass.
 function! TestDone() abort
+    call add(g:t_results, '  done')
     call writefile(g:t_results, '/dev/stdout', 'a')
     if g:t_failed > 0
         cquit

--- a/test/cases/cmdline.vim
+++ b/test/cases/cmdline.vim
@@ -1,0 +1,37 @@
+" Issue #62: :14y addresses an absolute line, but the gutter was relative
+" while typing it, so people kept acting on the wrong line. The command line
+" now shows absolute numbers.
+source <sfile>:h/../assert.vim
+
+let g:samples = []
+
+" <C-r>= evaluates while the command line is still open, which is the only
+" moment worth sampling.
+function! Sample() abort
+    call add(g:samples, &relativenumber)
+    return ''
+endfunction
+
+edit /tmp/numbers-test-a.txt
+call AssertNumbers('startup is hybrid', 1, 1)
+
+if exists('##CmdlineEnter')
+    call feedkeys(":\<C-r>=Sample()\<CR>\<CR>", 'x')
+    call Assert('#62 the : command line shows absolute numbers',
+                \ 'rnu=0', 'rnu=' . g:samples[0])
+    call AssertNumbers('#62 relative comes back afterwards', 1, 1)
+
+    " Searches take no line number, so they are deliberately left alone. The
+    " search has to match something real: an empty pattern raises E35, and
+    " cancelling with <Esc> hangs a headless editor.
+    call setline(1, ['alpha', 'beta', 'gamma'])
+    let g:samples = []
+    call feedkeys("/beta\<C-r>=Sample()\<CR>\<CR>", 'x')
+    call Assert('#62 searching does not switch',
+                \ 'rnu=1', 'rnu=' . g:samples[0])
+    call AssertNumbers('and the window is still hybrid', 1, 1)
+else
+    call Skip('#62 command line -- editor has no CmdlineEnter event')
+endif
+
+call TestDone()

--- a/test/run.sh
+++ b/test/run.sh
@@ -7,11 +7,17 @@
 # `" SETUP: <commands>` line, which the runner passes as --cmd before the
 # plugin loads.
 #
+# A case passes only if the editor exits 0 and the case printed its closing
+# "done" line. Anything else -- an error partway through, a prompt the editor
+# is waiting on, a crash -- is a failure.
+#
 # Usage: test/run.sh [case-name ...]
 
 set -u
 
 root=$(cd "$(dirname "$0")/.." && pwd)
+timeout_secs=${NUMBERS_TEST_TIMEOUT:-30}
+
 cases=()
 if [ $# -gt 0 ]; then
     for name in "$@"; do
@@ -30,28 +36,47 @@ passed=0
 failed=0
 ran_any=0
 
+# Bash has no portable timeout(1) -- macOS does not ship one -- so poll.
 run_case() {
-    local editor=$1 path=$2 setup args output status
-    setup=$(grep -m1 '^" SETUP: ' "$path" | cut -d: -f2-)
+    local editor=$1 path=$2
+    local setup args cmd tmp pid waited status
 
+    setup=$(grep -m1 '^" SETUP: ' "$path" | cut -d: -f2-)
     args=(--cmd "set rtp+=$root")
     if [ -n "$setup" ]; then
         args+=(--cmd "$setup")
     fi
 
-    # Stdin is closed throughout: an editor that hits an unexpected prompt
-    # should fail the case rather than block the run forever.
     if [ "$editor" = nvim ]; then
-        output=$(nvim --headless --clean "${args[@]}" -S "$path" </dev/null 2>&1)
-        status=$?
+        cmd=(nvim --headless --clean "${args[@]}" -S "$path")
     else
         # -u NORC keeps plugin loading enabled; -u NONE would disable it.
         # -es is silent Ex mode, which is why cases report via writefile().
-        output=$(vim -es -u NORC -N "${args[@]}" -S "$path" </dev/null 2>&1 | tr -d '\r')
-        status=${PIPESTATUS[0]}
+        cmd=(vim -es -u NORC -N "${args[@]}" -S "$path")
     fi
 
-    echo "$output"
+    tmp=$(mktemp)
+    # Stdin is closed so an unexpected prompt fails fast instead of blocking.
+    "${cmd[@]}" </dev/null >"$tmp" 2>&1 &
+    pid=$!
+
+    waited=0
+    while kill -0 "$pid" 2>/dev/null; do
+        if [ "$waited" -ge "$timeout_secs" ]; then
+            kill -9 "$pid" 2>/dev/null
+            wait "$pid" 2>/dev/null
+            tr -d '\r' <"$tmp"
+            rm -f "$tmp"
+            return 124
+        fi
+        sleep 1
+        waited=$((waited + 1))
+    done
+
+    wait "$pid"
+    status=$?
+    tr -d '\r' <"$tmp"
+    rm -f "$tmp"
     return $status
 }
 
@@ -66,10 +91,20 @@ for editor in vim nvim; do
     for path in "${cases[@]}"; do
         name=$(basename "$path" .vim)
         echo "$name"
-        if run_case "$editor" "$path"; then
-            passed=$((passed + 1))
-        else
+        out=$(run_case "$editor" "$path")
+        status=$?
+        echo "$out"
+
+        if [ "$status" -eq 124 ]; then
+            echo "  FAIL case timed out after ${timeout_secs}s"
             failed=$((failed + 1))
+        elif [ "$status" -ne 0 ]; then
+            failed=$((failed + 1))
+        elif ! printf '%s\n' "$out" | grep -q '^  done$'; then
+            echo "  FAIL case did not reach the end -- an error aborted it"
+            failed=$((failed + 1))
+        else
+            passed=$((passed + 1))
         fi
     done
     echo


### PR DESCRIPTION
## Summary
This change updates the numbers plugin so the gutter shows absolute line numbers while editing Ex commands, including the command-line case for `:14y`, while preserving the existing relative-number behavior elsewhere. It also adds coverage for the new command-line behavior and strengthens the test harness to detect hung or partially completed test cases more reliably.

## Changes Made
- Updated the plugin logic to switch to absolute numbering during Ex command-line entry and restore relative numbering afterward.
- Added documentation updates in the README and plugin docs to explain when numbers are absolute vs. relative.
- Added a new test case covering command-line behavior, including the `:14y` scenario and ensuring searches do not trigger the numbering mode switch.
- Expanded and adjusted shared test assertions/helpers to support the new behavior checks.
- Hardened the test runner to:
  - run cases with a configurable timeout,
  - detect cases that exit without reaching the expected end-of-test marker,
  - fail fast on unexpected prompts or hangs,
  - handle output capture more robustly across Vim and Neovim.

## Files Modified
- `README.md` — updated user-facing description of numbering behavior.
- `doc/numbers.txt` — updated plugin documentation with the new absolute-numbering cases.
- `plugin/numbers.vim` — added command-line handling for switching numbering modes.
- `test/assert.vim` — updated shared assertions/helpers for the new tests.
- `test/cases/cmdline.vim` — new test case for command-line and search behavior.
- `test/run.sh` — improved runner timeout, output handling, and failure detection.

## Important Notes
- The new behavior affects how line numbers are displayed while typing Ex commands, but only for command lines where an absolute line reference is relevant.
- Search command lines are intentionally left unchanged to avoid unnecessary flicker and mode switching.
- The test runner now treats timeouts and missing completion markers as failures, which may surface previously masked issues in existing test cases.
- Testing was added for both Vim and Neovim in the shell-based test harness.

Fixes #62