### PR TITLE
Restore line numbers when leaving excluded windows

### DIFF
--- a/plugin/numbers.vim
+++ b/plugin/numbers.vim
@@ -58,6 +58,12 @@ set cpo&vim
 let s:mode=0
 let s:center=1
 
+" Vim 7.3 before patch 1115 treats 'number' and 'relativenumber' as mutually
+" exclusive, so showing both at once is only possible after that.
+function! s:HasHybrid()
+    return has('nvim') || v:version > 703 || (v:version == 703 && has('patch1115'))
+endfunction
+
 function! NumbersRelativeOff()
     if has('nvim')
         set norelativenumber
@@ -107,6 +113,12 @@ function! ResetNumbers()
     if(s:center == 0)
         call NumbersRelativeOff()
     elseif(s:mode == 0)
+        " Undo the setlocal nonumber below for a window that is no longer
+        " excluded. Taken from the global value so that a user who turned
+        " numbers off themselves is not overridden.
+        if s:HasHybrid() && &g:number
+            setlocal number
+        endif
         set relativenumber
     else
         call NumbersRelativeOff()

--- a/test/cases/leaving_exclusion.vim
+++ b/test/cases/leaving_exclusion.vim
@@ -1,0 +1,35 @@
+" A window that stops being excluded gets its numbers back.
+"
+" Excluding a window uses setlocal nonumber, but the relative branch of
+" ResetNumbers only ever re-applied 'relativenumber'. A window that had shown
+" a sidebar filetype was left on relative-only numbering until it happened to
+" be left and re-entered.
+source <sfile>:h/../assert.vim
+
+edit /tmp/numbers-test-a.txt
+call AssertNumbers('normal buffer is hybrid', 1, 1)
+
+new
+setf nerdtree
+call AssertNumbers('sidebar filetype is excluded', 0, 0)
+
+setf text
+call AssertNumbers('numbers come back with an ordinary filetype', 1, 1)
+
+setf nerdtree
+call AssertNumbers('excluded again', 0, 0)
+edit! /tmp/numbers-test-b.txt
+call AssertNumbers('and come back when a real file is opened there', 1, 1)
+bwipeout!
+
+" A window is only restored to what the user actually asked for: turning
+" numbers off by hand has to stick.
+set nonumber
+new
+setf nerdtree
+call AssertNumbers('still excluded with numbers off globally', 0, 0)
+setf text
+call AssertNumbers('a global nonumber is not overridden', 0, 1)
+bwipeout!
+
+call TestDone()


### PR DESCRIPTION
## Summary
This change fixes an issue where windows that were previously excluded from numbering could remain in a relative-only state after switching back to a normal filetype. The plugin now restores `number` alongside `relativenumber` when appropriate, while still respecting a user’s explicit global `nonumber` setting.

## Changes Made
- Added `s:HasHybrid()` to detect whether the current Vim/Neovim version supports showing `number` and `relativenumber` together.
- Updated `ResetNumbers()` to re-enable local `number` when a window leaves an excluded state and hybrid numbering is supported.
- Preserved user intent by only restoring `number` when the global `number` option is enabled.
- Added a regression test covering:
  - entering and leaving excluded filetypes,
  - restoring hybrid numbering on return to a normal buffer,
  - preserving a manually disabled global `nonumber` setting.

## Files Modified
- `plugin/numbers.vim` — added version capability detection and restored `number` when re-enabling numbering for non-excluded windows.
- `test/cases/leaving_exclusion.vim` — added coverage for transitioning between excluded and non-excluded windows.

## Important Notes
- This behavior depends on Vim/Neovim support for hybrid line numbering; older Vim versions without patch 1115 will continue to behave as before.
- The change is intended to be non-breaking and respects explicit user configuration, especially `set nonumber`.
- Testing was added for the restored numbering flow and for the case where the user has globally disabled line numbers.