### PR TITLE
Bump version to 0.7.0

### DIFF
--- a/plugin/numbers.vim
+++ b/plugin/numbers.vim
@@ -1,9 +1,9 @@
 """"""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""
 " File:           numbers.vim
 " Maintainer:     Mahdi Yusuf yusuf.mahdi@gmail.com
-" Version:        0.6.1
+" Version:        0.7.0
 " Description:    vim global plugin for better line numbers.
-" Last Change:    15 September, 2013
+" Last Change:    1 August, 2026
 " License:        MIT License
 " Location:       plugin/numbers.vim
 " Website:        https://github.com/myusuf3/numbers.vim
@@ -14,7 +14,7 @@
 " :help numbers
 """"""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""
 
-let s:numbers_version = '0.5.0'
+let s:numbers_version = '0.7.0'
 
 if exists("g:loaded_numbers") && g:loaded_numbers
     finish


### PR DESCRIPTION
Version bump for the 0.7.0 release. Also syncs the stale `s:numbers_version` (which said 0.5.0 while the header said 0.6.1) and the Last Change date.

Note: `s:numbers_version` is never read anywhere. Syncing it here rather than deleting it, since removing it is a separate call - say the word and it goes.